### PR TITLE
Improve which_key and util functions

### DIFF
--- a/lua/wf/builtin/which_key.lua
+++ b/lua/wf/builtin/which_key.lua
@@ -51,7 +51,8 @@ local function which_key(opts)
         local mode = get_mode()
         local mode_shortname = mode:sub(1, 1)
         if modes[mode_shortname] == nil then
-            print("Not support mode: " .. mode_shortname)
+            print("Which Key does not support mode: " .. mode_shortname)
+            return
         end
         local g = _get_gmap("n")
         local b = _get_bmap(buf, "n")
@@ -64,7 +65,6 @@ local function which_key(opts)
         local _opts = {
             title = "Which Key",
             text_insert_in_advance = "",
-            -- key_group_dict = vim.fn.luaeval("_G.__kaza.prefix"),
         }
         local opts_ = ingect_deeply(_opts, opts)
 

--- a/lua/wf/util.lua
+++ b/lua/wf/util.lua
@@ -197,7 +197,7 @@ end
 function M.feedkeys(lhs, count, current, noremap)
     local mode_shortname = current.mode:sub(1, 1)
     local rhs = vim.fn.maparg(M.rt(lhs), mode_shortname, false, true)
-    local _feedkeys = function()
+    local _feedkeys = vim.schedule_wrap(function()
         if type(rhs["callback"]) == "function" then
             rhs["callback"]()
             if rhs.silent == 0 then
@@ -206,7 +206,7 @@ function M.feedkeys(lhs, count, current, noremap)
         else
             vim.api.nvim_feedkeys(M.rt(lhs), noremap and "n" or "m", false)
         end
-    end
+    end)
     local mode = current.mode
     if
         current.win == vim.api.nvim_get_current_win()

--- a/lua/wf/util.lua
+++ b/lua/wf/util.lua
@@ -194,7 +194,19 @@ function M.path_from_head(name, depth)
 end
 
 -- @param current: buf, win, mode
-function M.feedkeys(keys, count, current, noremap)
+function M.feedkeys(lhs, count, current, noremap)
+    local mode_shortname = current.mode:sub(1, 1)
+    local rhs = vim.fn.maparg(M.rt(lhs), mode_shortname, false, true)
+    local _feedkeys = function()
+        if type(rhs["callback"]) == "function" then
+            rhs["callback"]()
+            if rhs.silent == 0 then
+                vim.api.nvim_echo({ { rhs.lhsraw, "Normal" } }, false, {})
+            end
+        else
+            vim.api.nvim_feedkeys(M.rt(lhs), noremap and "n" or "m", false)
+        end
+    end
     local mode = current.mode
     if
         current.win == vim.api.nvim_get_current_win()
@@ -202,7 +214,7 @@ function M.feedkeys(keys, count, current, noremap)
     then
         local current_mode = vim.fn.mode()
         if count and count ~= 0 then
-            keys = count .. keys
+            lhs = count .. lhs
         end
         if current_mode == "i" then
             -- feed CTRL-O again i called from CTRL-O
@@ -213,11 +225,12 @@ function M.feedkeys(keys, count, current, noremap)
             end
 
             -- feed the keys with remap
-            vim.api.nvim_feedkeys(M.rt(keys), noremap and "n" or "m", false)
+            -- vim.api.nvim_feedkeys(M.rt(lhs), noremap and "n" or "m", false)
+            _feedkeys()
         elseif current_mode == "n" then
             if mode == "n" then
-                print(vim.inspect(vim.fn.maparg(M.rt(keys), "n")))
-                vim.api.nvim_feedkeys(M.rt(keys), noremap and "n" or "m", false)
+                -- vim.api.nvim_feedkeys(M.rt(lhs), noremap and "n" or "m", false)
+                _feedkeys()
             end
         else
             print("current mode: ", current_mode, "\n", "mode: ", mode)


### PR DESCRIPTION
- Update error message for unsupported mode in which_key.lua
- Remove `key_group_dict` option from which_key opts
- Add lhs maparg to nvim_feedkeys in util.lua
- Add callback and echo for lhs mapped argument
- Update feedkeys function to take lhs instead of keys
- Add check for current mode before feeding keys

[lua/wf/builtin/which_key.lua]
- Change the error message when an unsupported mode is used
- Remove the `key_group_dict` option from the `which_key` opts
- Add a return statement when an unsupported mode is used
[lua/wf/util.lua]
- Add a maparg to lhs before feeding it to nvim_feedkeys
- Add a callback and echo for the lhs mapped argument
- Update the feedkeys function to take lhs instead of keys
- Add a check for the current mode before feeding the keys## 📃 Summary

<!-- Provide some context about the pull request, it makes the review easier. -->

## 📸 Preview

<!-- If there's a visual impact to your change, please provide a screenshot. You can directly upload it to GitHub by dragging in this text area. -->
