### PR TITLE
Improve which_key.lua functionality

### DIFF
--- a/lua/wf/builtin/which_key.lua
+++ b/lua/wf/builtin/which_key.lua
@@ -70,14 +70,14 @@ local function which_key(opts)
 
         select(choices, opts_, function(_, lhs)
             local rhs = vim.fn.maparg(rt(lhs), mode_shortname, false, true)
-            if type(rhs["callback"]) == "function" then
-                rhs["callback"]()
-                if rhs.silent == 0 then
-                    vim.api.nvim_echo({ { rhs.lhsraw, "Normal" } }, false, {})
-                end
-            else
+            -- if type(rhs["callback"]) == "function" then
+            --     rhs["callback"]()
+            --     if rhs.silent == 0 then
+            --         vim.api.nvim_echo({ { rhs.lhsraw, "Normal" } }, false, {})
+            --     end
+            -- else
                 feedkeys(lhs, count, { win = win, buf = buf, mode = mode }, false)
-            end
+            -- end
         end)
     end
     return core


### PR DESCRIPTION
- Remove the conditional for calling the callback function in lua/wf/builtin/which_key.lua
- Remove the code for echoing the key pressed in Normal mode in lua/wf/builtin/which_key.lua

[lua/wf/builtin/which_key.lua]
- Remove the conditional for calling the callback function
- Remove the code for echoing the key pressed in Normal mode

## 📃 Summary

<!-- Provide some context about the pull request, it makes the review easier. -->

## 📸 Preview

<!-- If there's a visual impact to your change, please provide a screenshot. You can directly upload it to GitHub by dragging in this text area. -->
