### PR TITLE
fix: which_key for mappings with callback

### DIFF
--- a/lua/wf/builtin/which_key.lua
+++ b/lua/wf/builtin/which_key.lua
@@ -38,7 +38,7 @@ local function _get_bmap(buf, mode)
     if not string.match(val.lhs, "^<Plug>") then
       local lhs = val.lhs
       lhs = string.gsub(lhs, " ", "<Space>")
-      choices[lhs] = val.desc or val.rhs .. " [buf]" --or val.rhs
+      choices[lhs] = val.desc or val.rhs or tostring(val.callback) .. " [buf]" --or val.rhs
     end
   end
   return choices


### PR DESCRIPTION
## 📃 Summary

Mappings that use the `callback` argument and do not provide a `desc` argument will cause `which_key` to throw an error.
While this does not fix the issue of people forgetting to use a `desc` label in their mappings, it will at least make `which_key` usable in such cases
